### PR TITLE
change to consistency with base R functions regarding log.p, log and …

### DIFF
--- a/R/bernoulli-distribution.R
+++ b/R/bernoulli-distribution.R
@@ -31,7 +31,7 @@
 #' @export
 
 dbern <- function(x, prob = 0.5, log = FALSE) {
-  cpp_dbern(x, prob, log)
+  cpp_dbern(x, prob, log[1L])
 }
 
 
@@ -39,7 +39,7 @@ dbern <- function(x, prob = 0.5, log = FALSE) {
 #' @export
 
 pbern <- function(q, prob = 0.5, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pbern(q, prob, lower.tail, log.p)
+  cpp_pbern(q, prob, lower.tail[1L], log.p[1L])
 }
 
 
@@ -47,7 +47,7 @@ pbern <- function(q, prob = 0.5, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qbern <- function(p, prob = 0.5, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qbern(p, prob, lower.tail, log.p)
+  cpp_qbern(p, prob, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/beta-binomial-distribution.R
+++ b/R/beta-binomial-distribution.R
@@ -83,7 +83,7 @@
 #' @export
 
 dbbinom <- function(x, size, alpha = 1, beta = 1, log = FALSE) {
-  cpp_dbbinom(x, size, alpha, beta, log)
+  cpp_dbbinom(x, size, alpha, beta, log[1L])
 }
 
 
@@ -91,7 +91,7 @@ dbbinom <- function(x, size, alpha = 1, beta = 1, log = FALSE) {
 #' @export
 
 pbbinom <- function(q, size, alpha = 1, beta = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pbbinom(q, size, alpha, beta, lower.tail, log.p)
+  cpp_pbbinom(q, size, alpha, beta, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/beta-negative-binomial-distribution.R
+++ b/R/beta-negative-binomial-distribution.R
@@ -79,7 +79,7 @@
 #' @export
 
 dbnbinom <- function(x, size, alpha = 1, beta = 1, log = FALSE) {
-  cpp_dbnbinom(x, size, alpha, beta, log)
+  cpp_dbnbinom(x, size, alpha, beta, log[1L])
 }
 
 
@@ -87,7 +87,7 @@ dbnbinom <- function(x, size, alpha = 1, beta = 1, log = FALSE) {
 #' @export
 
 pbnbinom <- function(q, size, alpha = 1, beta = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pbnbinom(q, size, alpha, beta, lower.tail, log.p)
+  cpp_pbnbinom(q, size, alpha, beta, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/beta-prime-distribution.R
+++ b/R/beta-prime-distribution.R
@@ -58,7 +58,7 @@
 #' @export
 
 dbetapr <- function(x, shape1, shape2, scale = 1, log = FALSE) {
-  cpp_dbetapr(x, shape1, shape2, scale, log)
+  cpp_dbetapr(x, shape1, shape2, scale, log[1L])
 }
 
 
@@ -66,7 +66,7 @@ dbetapr <- function(x, shape1, shape2, scale = 1, log = FALSE) {
 #' @export
 
 pbetapr <- function(q, shape1, shape2, scale = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pbetapr(q, shape1, shape2, scale, lower.tail, log.p)
+  cpp_pbetapr(q, shape1, shape2, scale, lower.tail[1L], log.p[1L])
 }
 
 
@@ -74,7 +74,7 @@ pbetapr <- function(q, shape1, shape2, scale = 1, lower.tail = TRUE, log.p = FAL
 #' @export
 
 qbetapr <- function(p, shape1, shape2, scale = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qbetapr(p, shape1, shape2, scale, lower.tail, log.p)
+  cpp_qbetapr(p, shape1, shape2, scale, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/bhattacharjee-distribution.R
+++ b/R/bhattacharjee-distribution.R
@@ -65,7 +65,7 @@
 #' @export
 
 dbhatt <- function(x, mu = 0, sigma = 1, a = sigma, log = FALSE) {
-  cpp_dbhatt(x, mu, sigma, a, log)
+  cpp_dbhatt(x, mu, sigma, a, log[1L])
 }
 
 
@@ -73,7 +73,7 @@ dbhatt <- function(x, mu = 0, sigma = 1, a = sigma, log = FALSE) {
 #' @export
 
 pbhatt <- function(q, mu = 0, sigma = 1, a = sigma, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pbhatt(q, mu, sigma, a, lower.tail, log.p)
+  cpp_pbhatt(q, mu, sigma, a, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/birnbaum-saunders-distribution.R
+++ b/R/birnbaum-saunders-distribution.R
@@ -84,7 +84,7 @@
 #' @export
 
 dfatigue <- function(x, alpha, beta = 1, mu = 0, log = FALSE) {
-  cpp_dfatigue(x, alpha, beta, mu, log)
+  cpp_dfatigue(x, alpha, beta, mu, log[1L])
 }
 
 
@@ -92,7 +92,7 @@ dfatigue <- function(x, alpha, beta = 1, mu = 0, log = FALSE) {
 #' @export
 
 pfatigue <- function(q, alpha, beta = 1, mu = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pfatigue(q, alpha, beta, mu, lower.tail, log.p)
+  cpp_pfatigue(q, alpha, beta, mu, lower.tail[1L], log.p[1L])
 }
 
 
@@ -100,7 +100,7 @@ pfatigue <- function(q, alpha, beta = 1, mu = 0, lower.tail = TRUE, log.p = FALS
 #' @export
 
 qfatigue <- function(p, alpha, beta = 1, mu = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qfatigue(p, alpha, beta, mu, lower.tail, log.p)
+  cpp_qfatigue(p, alpha, beta, mu, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/bivariate-normal-distribution.R
+++ b/R/bivariate-normal-distribution.R
@@ -67,7 +67,7 @@ dbvnorm <- function(x, y = NULL, mean1 = 0, mean2 = mean1, sd1 = 1, sd2 = sd1, c
       stop("y is not provided while x is not a two-column matrix")
     }
   }
-  cpp_dbnorm(x, y, mean1, mean2, sd1, sd2, cor, log)
+  cpp_dbnorm(x, y, mean1, mean2, sd1, sd2, cor, log[1L])
 }
 
 

--- a/R/bivariate-poisson-distribution.R
+++ b/R/bivariate-poisson-distribution.R
@@ -69,7 +69,7 @@ dbvpois <- function(x, y = NULL, a, b, c, log = FALSE) {
       stop("y is not provided while x is not a two-column matrix")
     }
   }
-  cpp_dbpois(x, y, a, b, c, log)
+  cpp_dbpois(x, y, a, b, c, log[1L])
 }
 
 

--- a/R/categorical-distribution.R
+++ b/R/categorical-distribution.R
@@ -99,7 +99,7 @@ dcat <- function(x, prob, log = FALSE) {
     prob <- matrix(prob, nrow = 1L)
   else if (!is.matrix(prob))
     prob <- as.matrix(prob)
-  cpp_dcat(as.numeric(x), prob, log)
+  cpp_dcat(as.numeric(x), prob, log[1L])
 }
 
 
@@ -111,7 +111,7 @@ pcat <- function(q, prob, lower.tail = TRUE, log.p = FALSE) {
     prob <- matrix(prob, nrow = 1L)
   else if (!is.matrix(prob))
     prob <- as.matrix(prob)
-  cpp_pcat(as.numeric(q), prob, lower.tail, log.p)
+  cpp_pcat(as.numeric(q), prob, lower.tail[1L], log.p[1L])
 }
 
 
@@ -124,7 +124,7 @@ qcat <- function(p, prob, lower.tail = TRUE, log.p = FALSE, labels) {
   else if (!is.matrix(prob))
     prob <- as.matrix(prob)
   
-  x <- cpp_qcat(p, prob, lower.tail, log.p)
+  x <- cpp_qcat(p, prob, lower.tail[1L], log.p[1L])
   
   if (!missing(labels)) {
     if (length(labels) != ncol(prob))

--- a/R/dirichlet-distribution.R
+++ b/R/dirichlet-distribution.R
@@ -56,7 +56,7 @@ ddirichlet <- function(x, alpha, log = FALSE) {
     x <- as.matrix(x)
   else if (is.vector(x))
     x <- matrix(x, byrow = TRUE, nrow = 1)
-  cpp_ddirichlet(x, alpha, log)
+  cpp_ddirichlet(x, alpha, log[1L])
 }
 
 

--- a/R/dirichlet-multinomial-distribution.R
+++ b/R/dirichlet-multinomial-distribution.R
@@ -54,7 +54,7 @@ ddirmnom <- function(x, size, alpha, log = FALSE) {
     x <- as.matrix(x)
   else if (is.vector(x))
     x <- matrix(x, byrow = TRUE, nrow = 1)
-  cpp_ddirmnom(x, size, alpha, log)
+  cpp_ddirmnom(x, size, alpha, log[1L])
 }
 
 

--- a/R/discrete-gamma-distribution.R
+++ b/R/discrete-gamma-distribution.R
@@ -55,7 +55,7 @@ ddgamma <- function(x, shape, rate = 1, scale = 1/rate, log = FALSE) {
       warning("specify 'rate' or 'scale' but not both")
     else stop("specify 'rate' or 'scale' but not both")
   }
-  cpp_ddgamma(x, shape, scale, log)
+  cpp_ddgamma(x, shape, scale, log[1L])
 }
 
 
@@ -63,7 +63,7 @@ ddgamma <- function(x, shape, rate = 1, scale = 1/rate, log = FALSE) {
 #' @export
 
 pdgamma <- function(q, shape, rate = 1, scale = 1/rate, lower.tail = TRUE, log.p = FALSE) {
-  pgamma(floor(q)+1, shape, scale = scale, lower.tail = lower.tail, log.p = log.p)
+  pgamma(floor(q)+1, shape, scale = scale, lower.tail = lower.tail[1L], log.p = log.p[1L])
 }
 
 

--- a/R/discrete-laplace-distribution.R
+++ b/R/discrete-laplace-distribution.R
@@ -73,7 +73,7 @@
 #' @export
 
 ddlaplace <- function(x, location, scale, log = FALSE) {
-  cpp_ddlaplace(x, location, scale, log)
+  cpp_ddlaplace(x, location, scale, log[1L])
 }
 
 
@@ -81,7 +81,7 @@ ddlaplace <- function(x, location, scale, log = FALSE) {
 #' @export
 
 pdlaplace <- function(q, location, scale, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pdlaplace(q, location, scale, lower.tail, log.p)
+  cpp_pdlaplace(q, location, scale, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/discrete-normal-distribution.R
+++ b/R/discrete-normal-distribution.R
@@ -59,7 +59,7 @@
 #' @export
 
 ddnorm <- function(x, mean = 0, sd = 1, log = FALSE) {
-  cpp_ddnorm(x, mean, sd, log)
+  cpp_ddnorm(x, mean, sd, log[1L])
 }
 
 
@@ -67,7 +67,7 @@ ddnorm <- function(x, mean = 0, sd = 1, log = FALSE) {
 #' @export
 
 pdnorm <- function(q, mean = 0, sd = 1, lower.tail = TRUE, log.p = FALSE) {
-  pnorm(floor(q)+1, mean, sd, lower.tail, log.p)
+  pnorm(floor(q)+1, mean, sd, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/discrete-uniform-distribution.R
+++ b/R/discrete-uniform-distribution.R
@@ -40,7 +40,7 @@
 #' @export
 
 ddunif <- function(x, min, max, log = FALSE) {
-  cpp_ddunif(x, min, max, log)
+  cpp_ddunif(x, min, max, log[1L])
 }
 
 
@@ -48,7 +48,7 @@ ddunif <- function(x, min, max, log = FALSE) {
 #' @export
 
 pdunif <- function(q, min, max, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pdunif(q, min, max, lower.tail, log.p)
+  cpp_pdunif(q, min, max, lower.tail[1L], log.p[1L])
 }
 
 
@@ -56,7 +56,7 @@ pdunif <- function(q, min, max, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qdunif <- function(p, min, max, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qdunif(p, min, max, lower.tail, log.p)
+  cpp_qdunif(p, min, max, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/discrete-weibull-distribution.R
+++ b/R/discrete-weibull-distribution.R
@@ -79,7 +79,7 @@
 #' @export
 
 ddweibull <- function(x, shape1, shape2, log = FALSE) {
-  cpp_ddweibull(x, shape1, shape2, log)
+  cpp_ddweibull(x, shape1, shape2, log[1L])
 }
 
 
@@ -87,7 +87,7 @@ ddweibull <- function(x, shape1, shape2, log = FALSE) {
 #' @export
 
 pdweibull <- function(q, shape1, shape2, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pdweibull(q, shape1, shape2, lower.tail, log.p)
+  cpp_pdweibull(q, shape1, shape2, lower.tail[1L], log.p[1L])
 }
 
 
@@ -95,7 +95,7 @@ pdweibull <- function(q, shape1, shape2, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qdweibull <- function(p, shape1, shape2, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qdweibull(p, shape1, shape2, lower.tail, log.p)
+  cpp_qdweibull(p, shape1, shape2, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/frechet-distribution.R
+++ b/R/frechet-distribution.R
@@ -63,7 +63,7 @@
 #' @export
 
 dfrechet <- function(x, lambda = 1, mu = 0, sigma = 1, log = FALSE) {
-  cpp_dfrechet(x, lambda, mu, sigma, log)
+  cpp_dfrechet(x, lambda, mu, sigma, log[1L])
 }
 
 
@@ -71,7 +71,7 @@ dfrechet <- function(x, lambda = 1, mu = 0, sigma = 1, log = FALSE) {
 #' @export
 
 pfrechet <- function(q, lambda = 1, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pfrechet(q, lambda, mu, sigma, lower.tail, log.p)
+  cpp_pfrechet(q, lambda, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -79,7 +79,7 @@ pfrechet <- function(q, lambda = 1, mu = 0, sigma = 1, lower.tail = TRUE, log.p 
 #' @export
 
 qfrechet <- function(p, lambda = 1, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qfrechet(p, lambda, mu, sigma, lower.tail, log.p)
+  cpp_qfrechet(p, lambda, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/gamma-poisson-distribution.R
+++ b/R/gamma-poisson-distribution.R
@@ -75,7 +75,7 @@
 #' @export
 
 dgpois <- function(x, shape, rate, scale = 1/rate, log = FALSE) {
-  cpp_dgpois(x, shape, scale, log)
+  cpp_dgpois(x, shape, scale, log[1L])
 }
 
 
@@ -83,7 +83,7 @@ dgpois <- function(x, shape, rate, scale = 1/rate, log = FALSE) {
 #' @export
 
 pgpois <- function(q, shape, rate, scale = 1/rate, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pgpois(q, shape, scale, lower.tail, log.p)
+  cpp_pgpois(q, shape, scale, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/gev-distribution.R
+++ b/R/gev-distribution.R
@@ -70,7 +70,7 @@
 #' @export
 
 dgev <- function(x, mu = 0, sigma = 1, xi = 0, log = FALSE) {
-  cpp_dgev(x, mu, sigma, xi, log)
+  cpp_dgev(x, mu, sigma, xi, log[1L])
 }
 
 
@@ -78,7 +78,7 @@ dgev <- function(x, mu = 0, sigma = 1, xi = 0, log = FALSE) {
 #' @export
 
 pgev <- function(q, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pgev(q, mu, sigma, xi, lower.tail, log.p)
+  cpp_pgev(q, mu, sigma, xi, lower.tail[1L], log.p[1L])
 }
 
 
@@ -86,7 +86,7 @@ pgev <- function(q, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE)
 #' @export
 
 qgev <- function(p, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qgev(p, mu, sigma, xi, lower.tail, log.p)
+  cpp_qgev(p, mu, sigma, xi, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/gompertz-distribution.R
+++ b/R/gompertz-distribution.R
@@ -62,7 +62,7 @@
 #' @export
 
 dgompertz <- function(x, a = 1, b = 1, log = FALSE) {
-  cpp_dgompertz(x, a, b, log)
+  cpp_dgompertz(x, a, b, log[1L])
 }
 
 
@@ -70,7 +70,7 @@ dgompertz <- function(x, a = 1, b = 1, log = FALSE) {
 #' @export
 
 pgompertz <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pgompertz(q, a, b, lower.tail, log.p)
+  cpp_pgompertz(q, a, b, lower.tail[1L], log.p[1L])
 }
 
 
@@ -78,7 +78,7 @@ pgompertz <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qgompertz <- function(p, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qgompertz(p, a, b, lower.tail, log.p)
+  cpp_qgompertz(p, a, b, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/gpd-distribution.R
+++ b/R/gpd-distribution.R
@@ -70,7 +70,7 @@
 #' @export
 
 dgpd <- function(x, mu = 0, sigma = 1, xi = 0, log = FALSE) {
-  cpp_dgpd(x, mu, sigma, xi, log)
+  cpp_dgpd(x, mu, sigma, xi, log[1L])
 }
 
 
@@ -78,7 +78,7 @@ dgpd <- function(x, mu = 0, sigma = 1, xi = 0, log = FALSE) {
 #' @export
 
 pgpd <- function(q, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pgpd(q, mu, sigma, xi, lower.tail, log.p)
+  cpp_pgpd(q, mu, sigma, xi, lower.tail[1L], log.p[1L])
 }
 
 
@@ -86,7 +86,7 @@ pgpd <- function(q, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE)
 #' @export
 
 qgpd <- function(p, mu = 0, sigma = 1, xi = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qgpd(p, mu, sigma, xi, lower.tail, log.p)
+  cpp_qgpd(p, mu, sigma, xi, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/gumbel-distribution.R
+++ b/R/gumbel-distribution.R
@@ -61,7 +61,7 @@
 #' @export
 
 dgumbel <- function(x, mu = 0, sigma = 1, log = FALSE) {
-  cpp_dgumbel(x, mu, sigma, log)
+  cpp_dgumbel(x, mu, sigma, log[1L])
 }
 
 
@@ -69,7 +69,7 @@ dgumbel <- function(x, mu = 0, sigma = 1, log = FALSE) {
 #' @export
 
 pgumbel <- function(q, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pgumbel(q, mu, sigma, lower.tail, log.p)
+  cpp_pgumbel(q, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -77,7 +77,7 @@ pgumbel <- function(q, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qgumbel <- function(p, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qgumbel(p, mu, sigma, lower.tail, log.p)
+  cpp_qgumbel(p, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/half-cauchy-distribution.R
+++ b/R/half-cauchy-distribution.R
@@ -52,7 +52,7 @@
 #' @export
 
 dhcauchy <- function(x, sigma = 1, log = FALSE) {
-  cpp_dhcauchy(x, sigma, log)
+  cpp_dhcauchy(x, sigma, log[1L])
 }
 
 
@@ -60,7 +60,7 @@ dhcauchy <- function(x, sigma = 1, log = FALSE) {
 #' @export
 
 phcauchy <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_phcauchy(q, sigma, lower.tail, log.p)
+  cpp_phcauchy(q, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -68,7 +68,7 @@ phcauchy <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qhcauchy <- function(p, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qhcauchy(p, sigma, lower.tail, log.p)
+  cpp_qhcauchy(p, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/half-normal-distribution.R
+++ b/R/half-normal-distribution.R
@@ -52,7 +52,7 @@
 #' @export
 
 dhnorm <- function(x, sigma = 1, log = FALSE) {
-  cpp_dhnorm(x, sigma, log)
+  cpp_dhnorm(x, sigma, log[1L])
 }
 
 
@@ -60,7 +60,7 @@ dhnorm <- function(x, sigma = 1, log = FALSE) {
 #' @export
 
 phnorm <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_phnorm(q, sigma, lower.tail, log.p)
+  cpp_phnorm(q, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -68,7 +68,7 @@ phnorm <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qhnorm <- function(p, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qhnorm(p, sigma, lower.tail, log.p)
+  cpp_qhnorm(p, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/half-t-distribution.R
+++ b/R/half-t-distribution.R
@@ -51,7 +51,7 @@
 #' @export
 
 dht <- function(x, nu, sigma = 1, log = FALSE) {
-  cpp_dht(x, nu, sigma, log)
+  cpp_dht(x, nu, sigma, log[1L])
 }
 
 
@@ -59,7 +59,7 @@ dht <- function(x, nu, sigma = 1, log = FALSE) {
 #' @export
 
 pht <- function(q, nu, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pht(q, nu, sigma, lower.tail, log.p)
+  cpp_pht(q, nu, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -67,7 +67,7 @@ pht <- function(q, nu, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qht <- function(p, nu, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qht(p, nu, sigma, lower.tail, log.p)
+  cpp_qht(p, nu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/huber-distribution.R
+++ b/R/huber-distribution.R
@@ -75,7 +75,7 @@
 #' @export
 
 dhuber <- function(x, mu = 0, sigma = 1, epsilon = 1.345, log = FALSE) {
-  cpp_dhuber(x, mu, sigma, epsilon, log)
+  cpp_dhuber(x, mu, sigma, epsilon, log[1L])
 }
 
 
@@ -83,7 +83,7 @@ dhuber <- function(x, mu = 0, sigma = 1, epsilon = 1.345, log = FALSE) {
 #' @export
 
 phuber <- function(q, mu = 0, sigma = 1, epsilon = 1.345, lower.tail = TRUE, log.p = FALSE) {
-  cpp_phuber(q, mu, sigma, epsilon, lower.tail, log.p)
+  cpp_phuber(q, mu, sigma, epsilon, lower.tail[1L], log.p[1L])
 }
 
 
@@ -91,7 +91,7 @@ phuber <- function(q, mu = 0, sigma = 1, epsilon = 1.345, lower.tail = TRUE, log
 #' @export
 
 qhuber <- function(p, mu = 0, sigma = 1, epsilon = 1.345, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qhuber(p, mu, sigma, epsilon, lower.tail, log.p)
+  cpp_qhuber(p, mu, sigma, epsilon, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/inverse-chi-squared-distribution.R
+++ b/R/inverse-chi-squared-distribution.R
@@ -58,9 +58,9 @@
 
 dinvchisq <- function(x, nu, tau, log = FALSE) {
   if (missing(tau))
-    dinvgamma(x, nu/2, 0.5, log = log)
+    dinvgamma(x, nu/2, 0.5, log = log[1L])
   else
-    dinvgamma(x, nu/2, (nu*tau)/2, log = log)
+    dinvgamma(x, nu/2, (nu*tau)/2, log = log[1L])
 }
 
 
@@ -69,9 +69,9 @@ dinvchisq <- function(x, nu, tau, log = FALSE) {
 
 pinvchisq <- function(q, nu, tau, lower.tail = TRUE, log.p = FALSE) {
   if (missing(tau))
-    pgamma(1/q, nu/2, 0.5, lower.tail = !lower.tail, log.p = log.p)
+    pgamma(1/q, nu/2, 0.5, lower.tail = !lower.tail[1L], log.p = log.p[1L])
   else
-    pgamma(1/q, nu/2, (nu*tau)/2, lower.tail = !lower.tail, log.p = log.p)
+    pgamma(1/q, nu/2, (nu*tau)/2, lower.tail = !lower.tail[1L], log.p = log.p[1L])
 }
 
 
@@ -80,9 +80,9 @@ pinvchisq <- function(q, nu, tau, lower.tail = TRUE, log.p = FALSE) {
 
 qinvchisq <- function(p, nu, tau, lower.tail = TRUE, log.p = FALSE) {
   if (missing(tau))
-    1/qchisq(p, nu, lower.tail = !lower.tail, log.p = log.p)
+    1/qchisq(p, nu, lower.tail = !lower.tail[1L], log.p = log.p[1L])
   else
-    1/qgamma(p, nu/2, (nu*tau)/2, lower.tail = !lower.tail, log.p = log.p)
+    1/qgamma(p, nu/2, (nu*tau)/2, lower.tail = !lower.tail[1L], log.p = log.p[1L])
 }
 
 

--- a/R/inverse-gamma-distribution.R
+++ b/R/inverse-gamma-distribution.R
@@ -60,7 +60,7 @@
 #' @export
 
 dinvgamma <- function(x, alpha, beta = 1, log = FALSE) {
-  cpp_dinvgamma(x, alpha, 1/beta, log)
+  cpp_dinvgamma(x, alpha, 1/beta, log[1L])
 }
 
 
@@ -68,7 +68,7 @@ dinvgamma <- function(x, alpha, beta = 1, log = FALSE) {
 #' @export
 
 pinvgamma <- function(q, alpha, beta = 1, lower.tail = TRUE, log.p = FALSE) {
-  pgamma(1/q, alpha, beta, lower.tail = !lower.tail, log.p = log.p)
+  pgamma(1/q, alpha, beta, lower.tail = !lower.tail[1L], log.p = log.p[1L])
 }
 
 
@@ -76,7 +76,7 @@ pinvgamma <- function(q, alpha, beta = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qinvgamma <- function(p, alpha, beta = 1, lower.tail = TRUE, log.p = FALSE) {
-  1/qgamma(p, alpha, beta, lower.tail = !lower.tail, log.p = log.p)
+  1/qgamma(p, alpha, beta, lower.tail = !lower.tail[1L], log.p = log.p[1L])
 }
 
 

--- a/R/kumaraswamy-distribution.R
+++ b/R/kumaraswamy-distribution.R
@@ -65,7 +65,7 @@
 #' @export
 
 dkumar <- function(x, a = 1, b = 1, log = FALSE) {
-  cpp_dkumar(x, a, b, log)
+  cpp_dkumar(x, a, b, log[1L])
 }
 
 
@@ -73,7 +73,7 @@ dkumar <- function(x, a = 1, b = 1, log = FALSE) {
 #' @export
 
 pkumar <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pkumar(q, a, b, lower.tail, log.p)
+  cpp_pkumar(q, a, b, lower.tail[1L], log.p[1L])
 }
 
 
@@ -81,7 +81,7 @@ pkumar <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qkumar <- function(p, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qkumar(p, a, b, lower.tail, log.p)
+  cpp_qkumar(p, a, b, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/laplace-distribution.R
+++ b/R/laplace-distribution.R
@@ -71,7 +71,7 @@
 #' @export
 
 dlaplace <- function(x, mu = 0, sigma = 1, log = FALSE) {
-  cpp_dlaplace(x, mu, sigma, log)
+  cpp_dlaplace(x, mu, sigma, log[1L])
 }
 
 
@@ -79,7 +79,7 @@ dlaplace <- function(x, mu = 0, sigma = 1, log = FALSE) {
 #' @export
 
 plaplace <- function(q, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_plaplace(q, mu, sigma, lower.tail, log.p)
+  cpp_plaplace(q, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -87,7 +87,7 @@ plaplace <- function(q, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qlaplace <- function(p, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qlaplace(p, mu, sigma, lower.tail, log.p)
+  cpp_qlaplace(p, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/logarithmic-series-distribution.R
+++ b/R/logarithmic-series-distribution.R
@@ -66,7 +66,7 @@
 #' @export
 
 dlgser <- function(x, theta, log = FALSE) {
-  cpp_dlgser(x, theta, log)
+  cpp_dlgser(x, theta, log[1L])
 }
 
 
@@ -74,7 +74,7 @@ dlgser <- function(x, theta, log = FALSE) {
 #' @export
 
 plgser <- function(q, theta, lower.tail = TRUE, log.p = FALSE) {
-  cpp_plgser(q, theta, lower.tail, log.p)
+  cpp_plgser(q, theta, lower.tail[1L], log.p[1L])
 }
 
 
@@ -82,7 +82,7 @@ plgser <- function(q, theta, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qlgser <- function(p, theta, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qlgser(p, theta, lower.tail, log.p)
+  cpp_qlgser(p, theta, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/lomax-distribution.R
+++ b/R/lomax-distribution.R
@@ -57,7 +57,7 @@
 #' @export
 
 dlomax <- function(x, lambda, kappa, log = FALSE) {
-  cpp_dlomax(x, lambda, kappa, log)
+  cpp_dlomax(x, lambda, kappa, log[1L])
 }
 
 
@@ -65,7 +65,7 @@ dlomax <- function(x, lambda, kappa, log = FALSE) {
 #' @export
 
 plomax <- function(q, lambda, kappa, lower.tail = TRUE, log.p = FALSE) {
-  cpp_plomax(q, lambda, kappa, lower.tail, log.p)
+  cpp_plomax(q, lambda, kappa, lower.tail[1L], log.p[1L])
 }
 
 
@@ -73,7 +73,7 @@ plomax <- function(q, lambda, kappa, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qlomax <- function(p, lambda, kappa, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qlomax(p, lambda, kappa, lower.tail, log.p)
+  cpp_qlomax(p, lambda, kappa, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/multinomial-distribution.R
+++ b/R/multinomial-distribution.R
@@ -59,7 +59,7 @@ dmnom <- function(x, size, prob, log = FALSE) {
   else if (!is.matrix(x))
     x <- as.matrix(x)
   
-  cpp_dmnom(x, size, prob, log)
+  cpp_dmnom(x, size, prob, log[1L])
 }
 
 

--- a/R/multivariate-hypergeometric-distribution.R
+++ b/R/multivariate-hypergeometric-distribution.R
@@ -62,7 +62,7 @@ dmvhyper <- function(x, n, k, log = FALSE) {
   else if (!is.matrix(x))
     x <- as.matrix(x)
   
-  cpp_dmvhyper(x, n, k, log)
+  cpp_dmvhyper(x, n, k, log[1L])
 }
 
 

--- a/R/negative-hypergeometric-distribution.R
+++ b/R/negative-hypergeometric-distribution.R
@@ -91,7 +91,7 @@
 #' @export
 
 dnhyper <- function(x, n, m, r, log = FALSE) {
-  cpp_dnhyper(x, n, m, r, log)
+  cpp_dnhyper(x, n, m, r, log[1L])
 }
 
 
@@ -99,7 +99,7 @@ dnhyper <- function(x, n, m, r, log = FALSE) {
 #' @export
 
 pnhyper <- function(q, n, m, r, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pnhyper(q, n, m, r, lower.tail, log.p)
+  cpp_pnhyper(q, n, m, r, lower.tail[1L], log.p[1L])
 }
 
 
@@ -107,7 +107,7 @@ pnhyper <- function(q, n, m, r, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qnhyper <- function(p, n, m, r, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qnhyper(p, n, m, r, lower.tail, log.p)
+  cpp_qnhyper(p, n, m, r, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/non-standard-beta-distribution.R
+++ b/R/non-standard-beta-distribution.R
@@ -37,7 +37,7 @@
 #' @export
 
 dnsbeta <- function(x, shape1, shape2, min = 0, max = 1, log = FALSE) {
-  cpp_dnsbeta(x, shape1, shape2, min, max, log)
+  cpp_dnsbeta(x, shape1, shape2, min, max, log[1L])
 }
 
 
@@ -45,7 +45,7 @@ dnsbeta <- function(x, shape1, shape2, min = 0, max = 1, log = FALSE) {
 #' @export
 
 pnsbeta <- function(q, shape1, shape2, min = 0, max = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pnsbeta(q, shape1, shape2, min, max, lower.tail, log.p)
+  cpp_pnsbeta(q, shape1, shape2, min, max, lower.tail[1L], log.p[1L])
 }
 
 
@@ -53,7 +53,7 @@ pnsbeta <- function(q, shape1, shape2, min = 0, max = 1, lower.tail = TRUE, log.
 #' @export
 
 qnsbeta <- function(p, shape1, shape2, min = 0, max = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qnsbeta(p, shape1, shape2, min, max, lower.tail, log.p)
+  cpp_qnsbeta(p, shape1, shape2, min, max, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/non-standard-t-distribution.R
+++ b/R/non-standard-t-distribution.R
@@ -41,7 +41,7 @@
 #' @export
 
 dnst <- function(x, df, mu = 0, sigma = 1, log = FALSE) {
-  cpp_dnst(x, df, mu, sigma, log)
+  cpp_dnst(x, df, mu, sigma, log[1L])
 }
 
 
@@ -49,7 +49,7 @@ dnst <- function(x, df, mu = 0, sigma = 1, log = FALSE) {
 #' @export
 
 pnst <- function(q, df, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pnst(q, df, mu, sigma, lower.tail, log.p)
+  cpp_pnst(q, df, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -57,7 +57,7 @@ pnst <- function(q, df, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qnst <- function(p, df, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qnst(p, df, mu, sigma, lower.tail, log.p)
+  cpp_qnst(p, df, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/pareto-distribution.R
+++ b/R/pareto-distribution.R
@@ -61,7 +61,7 @@
 #' @export
 
 dpareto <- function(x, a = 1, b = 1, log = FALSE) {
-  cpp_dpareto(x, a, b, log)
+  cpp_dpareto(x, a, b, log[1L])
 }
 
 
@@ -69,7 +69,7 @@ dpareto <- function(x, a = 1, b = 1, log = FALSE) {
 #' @export
 
 ppareto <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_ppareto(q, a, b, lower.tail, log.p)
+  cpp_ppareto(q, a, b, lower.tail[1L], log.p[1L])
 }
 
 
@@ -77,7 +77,7 @@ ppareto <- function(q, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qpareto <- function(p, a = 1, b = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qpareto(p, a, b, lower.tail, log.p)
+  cpp_qpareto(p, a, b, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/power-distribution.R
+++ b/R/power-distribution.R
@@ -57,7 +57,7 @@
 #' @export
 
 dpower <- function(x, alpha, beta, log = FALSE) {
-  cpp_dpower(x, alpha, beta, log)
+  cpp_dpower(x, alpha, beta, log[1L])
 }
 
 
@@ -65,7 +65,7 @@ dpower <- function(x, alpha, beta, log = FALSE) {
 #' @export
 
 ppower <- function(q, alpha, beta, lower.tail = TRUE, log.p = FALSE) {
-  cpp_ppower(q, alpha, beta, lower.tail, log.p)
+  cpp_ppower(q, alpha, beta, lower.tail[1L], log.p[1L])
 }
 
 
@@ -73,7 +73,7 @@ ppower <- function(q, alpha, beta, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qpower <- function(p, alpha, beta, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qpower(p, alpha, beta, lower.tail, log.p)
+  cpp_qpower(p, alpha, beta, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/proportion-distribution.R
+++ b/R/proportion-distribution.R
@@ -87,7 +87,7 @@
 #' @export
 
 dprop <- function(x, size, mean, prior = 0, log = FALSE) {
-  cpp_dprop(x, size, mean, prior, log)
+  cpp_dprop(x, size, mean, prior, log[1L])
 }
 
 
@@ -95,7 +95,7 @@ dprop <- function(x, size, mean, prior = 0, log = FALSE) {
 #' @export
 
 pprop <- function(q, size, mean, prior = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pprop(q, size, mean, prior, lower.tail, log.p)
+  cpp_pprop(q, size, mean, prior, lower.tail[1L], log.p[1L])
 }
 
 
@@ -103,7 +103,7 @@ pprop <- function(q, size, mean, prior = 0, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qprop <- function(p, size, mean, prior = 0, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qprop(p, size, mean, prior, lower.tail, log.p)
+  cpp_qprop(p, size, mean, prior, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/rayleigh-distribution.R
+++ b/R/rayleigh-distribution.R
@@ -65,7 +65,7 @@
 #' @export
 
 drayleigh <- function(x, sigma = 1, log = FALSE) {
-  cpp_drayleigh(x, sigma, log)
+  cpp_drayleigh(x, sigma, log[1L])
 }
 
 
@@ -73,7 +73,7 @@ drayleigh <- function(x, sigma = 1, log = FALSE) {
 #' @export
 
 prayleigh <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_prayleigh(q, sigma, lower.tail, log.p)
+  cpp_prayleigh(q, sigma, lower.tail[1L], log.p[1L])
 }
 
 
@@ -81,7 +81,7 @@ prayleigh <- function(q, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qrayleigh <- function(p, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qrayleigh(p, sigma, lower.tail, log.p)
+  cpp_qrayleigh(p, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/shifted-gompertz-distribution.R
+++ b/R/shifted-gompertz-distribution.R
@@ -75,7 +75,7 @@
 #' @export
 
 dsgomp <- function(x, b, eta, log = FALSE) {
-  cpp_dsgomp(x, b, eta, log)
+  cpp_dsgomp(x, b, eta, log[1L])
 }
 
 
@@ -83,7 +83,7 @@ dsgomp <- function(x, b, eta, log = FALSE) {
 #' @export
 
 psgomp <- function(q, b, eta, lower.tail = TRUE, log.p = FALSE) {
-  cpp_psgomp(q, b, eta, lower.tail, log.p)
+  cpp_psgomp(q, b, eta, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/skellam-distribution.R
+++ b/R/skellam-distribution.R
@@ -51,7 +51,7 @@
 #' @export
 
 dskellam <- function(x, mu1, mu2, log = FALSE) {
-  cpp_dskellam(x, mu1, mu2, log)
+  cpp_dskellam(x, mu1, mu2, log[1L])
 }
 
 

--- a/R/slash-distribution.R
+++ b/R/slash-distribution.R
@@ -61,7 +61,7 @@
 #' @export
 
 dslash <- function(x, mu = 0, sigma = 1, log = FALSE) {
-  cpp_dslash(x, mu, sigma, log)
+  cpp_dslash(x, mu, sigma, log[1L])
 }
 
 
@@ -69,7 +69,7 @@ dslash <- function(x, mu = 0, sigma = 1, log = FALSE) {
 #' @export
 
 pslash <- function(q, mu = 0, sigma = 1, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pslash(q, mu, sigma, lower.tail, log.p)
+  cpp_pslash(q, mu, sigma, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/triangular-distribution.R
+++ b/R/triangular-distribution.R
@@ -83,7 +83,7 @@
 #' @export
 
 dtriang <- function(x, a = -1, b = 1, c = (a+b)/2, log = FALSE) {
-  cpp_dtriang(x, a, b, c, log)
+  cpp_dtriang(x, a, b, c, log[1L])
 }
 
 
@@ -91,7 +91,7 @@ dtriang <- function(x, a = -1, b = 1, c = (a+b)/2, log = FALSE) {
 #' @export
 
 ptriang <- function(q, a = -1, b = 1, c = (a+b)/2, lower.tail = TRUE, log.p = FALSE) {
-  cpp_ptriang(q, a, b, c, lower.tail, log.p)
+  cpp_ptriang(q, a, b, c, lower.tail[1L], log.p[1L])
 }
 
 
@@ -99,7 +99,7 @@ ptriang <- function(q, a = -1, b = 1, c = (a+b)/2, lower.tail = TRUE, log.p = FA
 #' @export
 
 qtriang <- function(p, a = -1, b = 1, c = (a+b)/2, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qtriang(p, a, b, c, lower.tail, log.p)
+  cpp_qtriang(p, a, b, c, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/truncated-binomial-distribution.R
+++ b/R/truncated-binomial-distribution.R
@@ -41,7 +41,7 @@
 #' @export
 
 dtbinom <- function(x, size, prob, a = -Inf, b = Inf, log = FALSE) {
-  cpp_dtbinom(x, size, prob, a, b, log)
+  cpp_dtbinom(x, size, prob, a, b, log[1L])
 }
 
 
@@ -49,7 +49,7 @@ dtbinom <- function(x, size, prob, a = -Inf, b = Inf, log = FALSE) {
 #' @export
 
 ptbinom <- function(q, size, prob, a = -Inf, b = Inf, lower.tail = TRUE, log.p = FALSE) {
-  cpp_ptbinom(q, size, prob, a, b, lower.tail, log.p)
+  cpp_ptbinom(q, size, prob, a, b, lower.tail[1L], log.p[1L])
 }
 
 
@@ -57,7 +57,7 @@ ptbinom <- function(q, size, prob, a = -Inf, b = Inf, lower.tail = TRUE, log.p =
 #' @export
 
 qtbinom <- function(p, size, prob, a = -Inf, b = Inf, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qtbinom(p, size, prob, a, b, lower.tail, log.p)
+  cpp_qtbinom(p, size, prob, a, b, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/truncated-normal-distribution.R
+++ b/R/truncated-normal-distribution.R
@@ -102,7 +102,7 @@
 #' @export
 
 dtnorm <- function(x, mean = 0, sd = 1, a = -Inf, b = Inf, log = FALSE) {
-  cpp_dtnorm(x, mean, sd, a, b, log)
+  cpp_dtnorm(x, mean, sd, a, b, log[1L])
 }
 
 
@@ -110,7 +110,7 @@ dtnorm <- function(x, mean = 0, sd = 1, a = -Inf, b = Inf, log = FALSE) {
 #' @export
 
 ptnorm <- function(q, mean = 0, sd = 1, a = -Inf, b = Inf, lower.tail = TRUE, log.p = FALSE) {
-  cpp_ptnorm(q, mean, sd, a, b, lower.tail, log.p)
+  cpp_ptnorm(q, mean, sd, a, b, lower.tail[1L], log.p[1L])
 }
 
 
@@ -118,7 +118,7 @@ ptnorm <- function(q, mean = 0, sd = 1, a = -Inf, b = Inf, lower.tail = TRUE, lo
 #' @export
 
 qtnorm <- function(p, mean = 0, sd = 1, a = -Inf, b = Inf, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qtnorm(p, mean, sd, a, b, lower.tail, log.p)
+  cpp_qtnorm(p, mean, sd, a, b, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/tuckey-lambda-distribution.R
+++ b/R/tuckey-lambda-distribution.R
@@ -71,7 +71,7 @@
 #' @export
 
 qtlambda <- function(p, lambda, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qtlambda(p, lambda, lower.tail, log.p)
+  cpp_qtlambda(p, lambda, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/wald-distribution.R
+++ b/R/wald-distribution.R
@@ -61,7 +61,7 @@
 #' @export
 
 dwald <- function(x, mu, lambda, log = FALSE) {
-  cpp_dwald(x, mu, lambda, log)
+  cpp_dwald(x, mu, lambda, log[1L])
 }
 
 
@@ -69,7 +69,7 @@ dwald <- function(x, mu, lambda, log = FALSE) {
 #' @export
 
 pwald <- function(q, mu, lambda, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pwald(q, mu, lambda, lower.tail, log.p)
+  cpp_pwald(q, mu, lambda, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/zero-inflated-binomial-distribution.R
+++ b/R/zero-inflated-binomial-distribution.R
@@ -52,7 +52,7 @@
 #' @export
 
 dzib <- function(x, size, prob, pi, log = FALSE) {
-  cpp_dzib(x, size, prob, pi, log)
+  cpp_dzib(x, size, prob, pi, log[1L])
 }
 
 
@@ -60,7 +60,7 @@ dzib <- function(x, size, prob, pi, log = FALSE) {
 #' @export
 
 pzib <- function(q, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pzib(q, size, prob, pi, lower.tail, log.p)
+  cpp_pzib(q, size, prob, pi, lower.tail[1L], log.p[1L])
 }
 
 
@@ -68,7 +68,7 @@ pzib <- function(q, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qzib <- function(p, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qzib(p, size, prob, pi, lower.tail, log.p)
+  cpp_qzib(p, size, prob, pi, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/zero-inflated-negative-binomial-distribution.R
+++ b/R/zero-inflated-negative-binomial-distribution.R
@@ -55,7 +55,7 @@
 #' @export
 
 dzinb <- function(x, size, prob, pi, log = FALSE) {
-  cpp_dzinb(x, size, prob, pi, log)
+  cpp_dzinb(x, size, prob, pi, log[1L])
 }
 
 
@@ -63,7 +63,7 @@ dzinb <- function(x, size, prob, pi, log = FALSE) {
 #' @export
 
 pzinb <- function(q, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pzinb(q, size, prob, pi, lower.tail, log.p)
+  cpp_pzinb(q, size, prob, pi, lower.tail[1L], log.p[1L])
 }
 
 
@@ -71,7 +71,7 @@ pzinb <- function(q, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qzinb <- function(p, size, prob, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qzinb(p, size, prob, pi, lower.tail, log.p)
+  cpp_qzinb(p, size, prob, pi, lower.tail[1L], log.p[1L])
 }
 
 

--- a/R/zero-inflated-poisson-distribution.R
+++ b/R/zero-inflated-poisson-distribution.R
@@ -51,7 +51,7 @@
 #' @export
 
 dzip <- function(x, lambda, pi, log = FALSE) {
-  cpp_dzip(x, lambda, pi, log)
+  cpp_dzip(x, lambda, pi, log[1L])
 }
 
 
@@ -59,7 +59,7 @@ dzip <- function(x, lambda, pi, log = FALSE) {
 #' @export
 
 pzip <- function(q, lambda, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_pzip(q, lambda, pi, lower.tail, log.p)
+  cpp_pzip(q, lambda, pi, lower.tail[1L], log.p[1L])
 }
 
 
@@ -67,7 +67,7 @@ pzip <- function(q, lambda, pi, lower.tail = TRUE, log.p = FALSE) {
 #' @export
 
 qzip <- function(p, lambda, pi, lower.tail = TRUE, log.p = FALSE) {
-  cpp_qzip(p, lambda, pi, lower.tail, log.p)
+  cpp_qzip(p, lambda, pi, lower.tail[1L], log.p[1L])
 }
 
 


### PR DESCRIPTION
Currently the documentation (and practice) for distribution functions in base R (eg `dnorm` / `rpois`) "Only the first elements of the logical arguments are used" 

This means the following works in base R
```r
dnorm(1, log = c(TRUE, FALSE))
# [1] -1.418939
```

This pull request will stop extraDistr returning errors such as

```r
extraDistr::pgev(1, log.p = c(TRUE, FALSE))
#Error in cpp_pgev(q, mu, sigma, xi, lower.tail, log.p) : 
 #  expecting a single value
```

In some situations, when using base R functions directly, no errors are given, and the functions return using the first value

```r
extraDistr::pdnorm(1, log = c(TRUE, FALSE))
# [1] -0.02301291
```


