### PR TITLE
Remove LazyData field from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,6 @@ License: GPL-2
 URL: https://github.com/twolodzko/extraDistr
 BugReports: https://github.com/twolodzko/extraDistr/issues
 Encoding: UTF-8
-LazyData: TRUE
 Depends: R (>= 3.1.0)
 LinkingTo: Rcpp
 Imports: Rcpp


### PR DESCRIPTION
Since this package doesn't provide data (no `data/` folder in this repository), the `LazyData` field in `DESCRIPTION` is not applicable and should not be present.

This will solve the following CRAN check warning:

>  'LazyData' is specified without a 'data' directory

Part of #29 